### PR TITLE
Improve README references and usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ _A technical-scientific guide to `genomes_analyzer.py`_
 
 ## Abstract
 
-High-throughput DNA sequencing has transformed biological and clinical research, but turning raw reads into actionable variant calls still requires a reliable, explainable, and resource-efficient pipeline. **Genomes Analyzer** is a Python-driven workflow designed to take one or more whole-genome or exome samples from raw FASTQ (or pre-aligned BAM/CRAM) to compressed, indexed VCF. It emphasizes clear provenance, conservative defaults, and transparent logging while remaining pragmatic about compute and memory on commodity Linux workstations. The pipeline integrates widely used open-source tools—`FastQC` for read quality control, `cutadapt` for adapter/quality trimming, `bwa-mem2` for alignment, `samtools` for sorting/indexing/duplicate marking, and a selectable variant-calling backend: either **GATK** (HaplotypeCaller → GenotypeGVCFs) or **BCFtools** (`mpileup` → `call` → `norm`). To keep runtimes reasonable, Genomes Analyzer splits the reference into **shards** (BED intervals) and executes them in parallel with safe concatenation and indexing, while preserving chromosome order. It prints human-readable progress dashboards (including the shard BED preview and per-shard heartbeats) so researchers can monitor long runs without guesswork.
+High-throughput DNA sequencing has transformed biological and clinical research, but turning raw reads into actionable variant calls still requires a reliable, explainable, and resource-efficient pipeline. **Genomes Analyzer** is a Python-driven workflow designed to take one or more whole-genome or exome samples from raw [FASTQ](https://en.wikipedia.org/wiki/FASTQ_format) (or pre-aligned [BAM/CRAM](https://en.wikipedia.org/wiki/SAM_(file_format))) to compressed, indexed [VCF](https://samtools.github.io/hts-specs/VCFv4.3.pdf). It emphasizes clear provenance, conservative defaults, and transparent logging while remaining pragmatic about compute and memory on commodity Linux workstations. The pipeline integrates widely used open-source tools—[FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/) for read quality control, [cutadapt](https://cutadapt.readthedocs.io/) for adapter/quality trimming, [bwa-mem2](https://github.com/bwa-mem2/bwa-mem2) for alignment, [samtools](http://www.htslib.org/) for sorting/indexing/duplicate marking, and a selectable variant-calling backend: either [GATK](https://gatk.broadinstitute.org/hc/en-us) (HaplotypeCaller → GenotypeGVCFs) or [BCFtools](https://samtools.github.io/bcftools/) (`mpileup` → `call` → `norm`). To keep runtimes reasonable, Genomes Analyzer splits the reference into **shards** ([BED](https://genome.ucsc.edu/FAQ/FAQformat.html#format1) intervals) and executes them in parallel with safe concatenation and indexing, while preserving chromosome order. It prints human-readable progress dashboards (including the shard BED preview and per-shard heartbeats) so researchers can monitor long runs without guesswork.
 
 This document introduces the pipeline to readers **without assuming prior genomics expertise**. We define essential terms (e.g., FASTQ, BAM/CRAM, VCF, read mapping, duplicate marking, genotyping, normalization), explain each processing step and its rationale, and show representative snippets of intermediate and final outputs. We also document configuration via YAML, including paths, sample declarations, quality/coverage thresholds, and parallelization parameters. Finally, we provide an appendix detailing the external genomics tools used, typical command patterns, and commonly tuned parameters. The goal is to enable reproducible analyses with sensible defaults while making it straightforward to adapt the pipeline to different datasets, hardware budgets, and scientific objectives.
 
@@ -32,7 +32,7 @@ This document introduces the pipeline to readers **without assuming prior genomi
 
 ## Genomes Analyzer Pipeline
 
-The workflow transforms raw reads into variant calls through a series of well-defined stages. Each acronym is introduced before use so that readers new to genomics can follow along.
+Before running the workflow, make sure the environment is prepared as described in [How to Use the Genomes Analyzer](#how-to-use-the-genomes-analyzer). The workflow transforms raw reads into variant calls through a series of well-defined stages. Each acronym is introduced before use so that readers new to genomics can follow along.
 
 ```
 FASTQ
@@ -50,7 +50,7 @@ FASTQ
   └── Final VCF quality control
 ```
 
-### 1. Read Quality Control — FastQC
+### 1. Read Quality Control — [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)
 
 **FASTQ** files store sequencing reads and their per-base quality scores. `FastQC` scans these files and produces HTML reports summarizing quality metrics such as Phred scores, nucleotide composition, and overrepresented sequences.
 
@@ -68,7 +68,7 @@ FASTQ
 
 *Outputs*: `qc/<sample>_R1_fastqc.html`, `qc/<sample>_R2_fastqc.html` plus compressed archives containing raw metrics.
 
-### 2. Adapter and Quality Trimming — cutadapt
+### 2. Adapter and Quality Trimming — [cutadapt](https://cutadapt.readthedocs.io/)
 
 Sequencing libraries often carry leftover **adapter** sequences and low-quality ends. `cutadapt` removes these artifacts and can filter short reads.
 
@@ -86,9 +86,9 @@ Quality-trimmed:                1.6 Gbp (1.4%)
 
 *Outputs*: `trimmed/<sample>_R1.fastq.gz`, `trimmed/<sample>_R2.fastq.gz`.
 
-### 3. Alignment — BWA‑MEM2
+### 3. Alignment — [BWA‑MEM2](https://github.com/bwa-mem2/bwa-mem2)
 
-`bwa-mem2` maps each read pair to the reference genome. The output is a **SAM** (Sequence Alignment/Map) stream that records candidate genomic coordinates, alignment scores, and flags. Alignments are typically converted on the fly to the binary **BAM** format.
+`bwa-mem2` maps each read pair to the reference genome. The output is a **[SAM](https://en.wikipedia.org/wiki/SAM_(file_format))** (Sequence Alignment/Map) stream that records candidate genomic coordinates, alignment scores, and flags. Alignments are typically converted on the fly to the binary **BAM** format.
 
 *Why it matters*: Accurate mapping is a prerequisite to reliable variant detection. Each read receives a mapping quality score indicating confidence in its genomic position.
 
@@ -102,7 +102,7 @@ Quality-trimmed:                1.6 Gbp (1.4%)
 
 *Outputs*: `aligned/<sample>.sam` (usually streamed downstream).
 
-### 4. Sorting & Indexing — samtools
+### 4. Sorting & Indexing — [samtools](http://www.htslib.org/)
 
 `samtools sort` arranges BAM records by genomic coordinate and writes an index (`.bai`) to enable random access.
 
@@ -110,7 +110,7 @@ Quality-trimmed:                1.6 Gbp (1.4%)
 
 *Outputs*: `bam/<sample>.sorted.bam`, `bam/<sample>.sorted.bam.bai`.
 
-### 5. Duplicate Marking — samtools markdup
+### 5. Duplicate Marking — [samtools markdup](http://www.htslib.org/)
 
 PCR amplification and optical artifacts can yield **duplicate reads**—multiple observations of the same DNA fragment. `samtools markdup` flags these duplicates so that callers can ignore them.
 
@@ -118,7 +118,7 @@ PCR amplification and optical artifacts can yield **duplicate reads**—multiple
 
 *Outputs*: `bam/<sample>.mkdup.bam`, `bam/<sample>.mkdup.bam.bai`.
 
-### 6. Optional Base Quality Score Recalibration — GATK BQSR
+### 6. Optional Base Quality Score Recalibration — [GATK](https://gatk.broadinstitute.org/hc/en-us) BQSR
 
 Sequencing machines sometimes misestimate base quality scores. **Base Quality Score Recalibration (BQSR)** uses known variant sites to adjust these scores.
 
@@ -128,7 +128,7 @@ Sequencing machines sometimes misestimate base quality scores. **Base Quality Sc
 
 ### 7. Sharding the Reference Genome
 
-Large genomes are divided into manageable **BED** intervals ("shards"). Each shard is processed independently to leverage parallelism.
+Large genomes are divided into manageable **[BED](https://genome.ucsc.edu/FAQ/FAQformat.html#format1)** intervals ("shards"). Each shard is processed independently to leverage parallelism.
 
 *Why it matters*: Short-read variant callers parallelize poorly within a single region; sharding provides coarse-grained parallelism across chromosomes/blocks and reduces wall-clock time.
 
@@ -138,14 +138,14 @@ Large genomes are divided into manageable **BED** intervals ("shards"). Each sha
 
 At this stage, aligned reads are converted into genomic variants. Two backends are available:
 
-#### A. GATK HaplotypeCaller → GenotypeGVCFs
+#### A. [GATK](https://gatk.broadinstitute.org/hc/en-us) HaplotypeCaller → GenotypeGVCFs
 
 1. **HaplotypeCaller** analyzes each shard, performing local re-assembly to produce per-sample genomic VCFs (**gVCFs**).
 2. **GenotypeGVCFs** merges gVCFs and emits a final VCF with genotypes.
 
 *Outputs*: `vcf/<sample>.g.vcf.gz`, `vcf/<sample>.vcf.gz` and their indexes.
 
-#### B. BCFtools mpileup → call → norm
+#### B. [BCFtools](https://samtools.github.io/bcftools/) mpileup → call → norm
 
 1. **mpileup** summarizes read evidence at each position, applying mapping-quality (MAPQ) and base-quality (BASEQ) filters.
 2. **call** infers SNPs and indels using a multiallelic model.
@@ -161,7 +161,7 @@ Per-shard VCFs are concatenated in chromosome order and re-indexed so that downs
 
 ### 10. Optional VCF Quality Control
 
-`bcftools stats` and related utilities generate summary metrics and plots to assess callset quality.
+[`bcftools stats`](https://samtools.github.io/bcftools/howtos/stats.html) and related utilities generate summary metrics and plots to assess callset quality.
 
 *Outputs*: `qc/<sample>.bcftools.stats.txt` and optional graphical summaries via `plot-vcfstats` or `MultiQC`.
 
@@ -180,9 +180,21 @@ Per-shard VCFs are concatenated in chromosome order and re-indexed so that downs
 
 ### Installation
 
-1. Install a Python environment (e.g., via [conda](https://docs.conda.io/)).
-2. Optional helper script: `install_genomics_env.sh` installs common genomics packages.
-3. Activate the environment: `source start_genomics.sh`.
+1. Use a Unix-like system with [Python](https://www.python.org/) 3.10 or newer available.
+2. Create an isolated environment, for example with [conda](https://docs.conda.io/):
+   ```bash
+   conda create -n genomes python=3.10
+   conda activate genomes
+   ```
+3. Run the helper script to install required bioinformatics tools (FastQC, cutadapt, bwa-mem2, samtools, bcftools, GATK):
+   ```bash
+   bash install_genomics_env.sh
+   ```
+   The script downloads binaries and adds them to `PATH`.
+4. Configure shell variables and paths for the session:
+   ```bash
+   source start_genomics.sh
+   ```
 
 ### YAML Configuration: `config_human_30x_low_memory.yaml`
 
@@ -296,12 +308,36 @@ The pipeline wraps several established command‑line programs. Table 1 summari
 
 | Tool | Role | Typical command | Key parameters |
 |------|------|----------------|----------------|
-| FastQC | Read quality assessment | `fastqc -t 8 fastq/*_R{1,2}.fastq.gz -o qc/` | `-t` threads |
-| cutadapt | Adapter and quality trimming | `cutadapt -j 8 -q 20,20 -m 30 -a ADAPT1 -A ADAPT2 -o out_R1.fastq.gz -p out_R2.fastq.gz in_R1.fastq.gz in_R2.fastq.gz` | `-q` quality cutoff, `-m` min length, `-a/-A` adapters |
-| BWA‑MEM2 | Short‑read alignment | `bwa-mem2 mem -t 16 -R "@RG\tID:S\tSM:S" refs.fa R1.fq.gz R2.fq.gz` | `-t` threads, `-R` read group |
-| samtools | BAM/CRAM processing | `samtools sort -@8 -o out.bam in.bam` | `-@` threads |
-| BCFtools | Variant calling and manipulation | `bcftools mpileup -f refs.fa -q20 -Q20 | bcftools call -m -v -Oz -o out.vcf.gz` | `-q/-Q` quality filters, `-m` multiallelic model |
-| GATK | Variant calling (Java) | `gatk --java-options "-Xmx24g" HaplotypeCaller -R refs.fa -I in.bam -O out.g.vcf.gz` | `--java-options` memory, `-L` intervals |
+| [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/) | Read quality assessment | `fastqc -t 8 fastq/*_R{1,2}.fastq.gz -o qc/` | `-t` threads |
+| [cutadapt](https://cutadapt.readthedocs.io/) | Adapter and quality trimming | `cutadapt -j 8 -q 20,20 -m 30 -a ADAPT1 -A ADAPT2 -o out_R1.fastq.gz -p out_R2.fastq.gz in_R1.fastq.gz in_R2.fastq.gz` | `-q` quality cutoff, `-m` min length, `-a/-A` adapters |
+| [BWA‑MEM2](https://github.com/bwa-mem2/bwa-mem2) | Short‑read alignment | `bwa-mem2 mem -t 16 -R "@RG\tID:S\tSM:S" refs.fa R1.fq.gz R2.fq.gz` | `-t` threads, `-R` read group |
+| [samtools](http://www.htslib.org/) | BAM/CRAM processing | `samtools sort -@8 -o out.bam in.bam` | `-@` threads |
+| [BCFtools](https://samtools.github.io/bcftools/) | Variant calling and manipulation | `bcftools mpileup -f refs.fa -q20 -Q20 | bcftools call -m -v -Oz -o out.vcf.gz` | `-q/-Q` quality filters, `-m` multiallelic model |
+| [GATK](https://gatk.broadinstitute.org/hc/en-us) | Variant calling (Java) | `gatk --java-options "-Xmx24g" HaplotypeCaller -R refs.fa -I in.bam -O out.g.vcf.gz` | `--java-options` memory, `-L` intervals |
 
 Each tool offers many more options; consult the official manuals for advanced usage. The examples above match how `genomes_analyzer.py` invokes them under default settings.
+
+### FastQC
+
+`FastQC` evaluates base-call quality, sequence content and other metrics for raw reads. The example command above scans paired FASTQ files and writes an HTML report and a compressed archive to `qc/`. Successful runs produce files named `*_fastqc.html` and `*_fastqc.zip`.
+
+### cutadapt
+
+`cutadapt` removes adapter sequences and trims low-quality bases. Running the sample command yields trimmed FASTQ files (`out_R1.fastq.gz`, `out_R2.fastq.gz`) and a log describing how many reads were modified or discarded.
+
+### BWA‑MEM2
+
+`bwa-mem2` aligns reads to a reference genome. The output is typically piped to `samtools` to create BAM files. Expect alignment statistics on `stderr` and an alignment stream on `stdout`.
+
+### samtools
+
+`samtools` manipulates SAM/BAM/CRAM files. The sorting example writes a coordinate-sorted BAM (`out.bam`) and reports progress percentages while running. Additional subcommands handle indexing, duplicate marking and more.
+
+### BCFtools
+
+`BCFtools` calls and filters variants. The example pipeline (`mpileup` → `call`) emits a compressed VCF (`out.vcf.gz`) and writes call statistics to `stderr`. The `norm` step (not shown) normalizes indels and splits multiallelic records.
+
+### GATK
+
+The Java-based `GATK` suite provides sophisticated variant calling. `HaplotypeCaller` generates per-sample gVCFs, and tools like `GenotypeGVCFs` merge them. Outputs include `out.g.vcf.gz` and corresponding indexes, with detailed progress logs in the console.
 


### PR DESCRIPTION
## Summary
- Add external reference links for genomics formats and tools
- Link Genomes Analyzer Pipeline section to usage instructions
- Expand installation notes and tool descriptions in Appendix 1

## Testing
- `python genomes_analyzer.py --help` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68ae865e03d4832e922318ade2e2b95e